### PR TITLE
API migration v1 -> v4

### DIFF
--- a/updateCloudFlare.php
+++ b/updateCloudFlare.php
@@ -16,7 +16,11 @@ $hosts = array(
 );
 
 // Check the calling client has a valid auth key.
-if(empty($_GET['auth']) || (!array_key_exists($_GET['auth'], $hosts))) die;
+if (empty($_GET['auth'])) {
+	die("Authentication required\n");
+} elseif (!array_key_exists($_GET['auth'], $hosts)) {
+	die("Invalid auth key\n");
+}
 
 // Update these values with your own information.
 $apiKey       = "CloudFlareApiKey";                         // Your CloudFlare API Key.
@@ -26,66 +30,22 @@ $emailAddress = "CloudFlareAccountEmailAddress";            // The email address
 // These values do not need to be changed.
 if (empty($hosts[$_GET['auth']]))
     $ddnsAddress  = $myDomain;                              // If no subdomain is given, update the domain itself.
-else
-    $ddnsAddress  = $hosts[$_GET['auth']].".".$myDomain;    // The subdomain that will be updated.
-$ip           = $_SERVER['REMOTE_ADDR'];                    // The IP of the client calling the script.
-$id           = 0;                                          // The CloudFlare ID of the subdomain, used later.
-$url          = 'https://www.cloudflare.com/api_json.html'; // The URL for the CloudFlare API.
-$cfIP	      = '';					    // The IP Cloudflare has for the subdomain.
-
-// Build the initial request to fetch the record ID.
-// https://www.cloudflare.com/docs/client-api.html#s3.3
-$fields = array(
-	'a' => urlencode('rec_load_all'),
-        'tkn' => urlencode($apiKey),
-	'email' => urlencode($emailAddress),
-	'z' => urlencode($myDomain)
-);
-
-$fields_string="";
-foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
-rtrim($fields_string, '&');
-
-// Send the request to the CloudFlare API.
-$ch = curl_init();
-curl_setopt($ch,CURLOPT_URL, $url);
-curl_setopt($ch,CURLOPT_POST, count($fields));
-curl_setopt($ch,CURLOPT_POSTFIELDS, $fields_string);
-curl_setopt($ch,CURLOPT_RETURNTRANSFER, true);
-$result = curl_exec($ch);
-curl_close($ch);
-
-// Extract the record ID for the subdomain we want to update.
-$data = json_decode($result);
-foreach($data->response->recs->objs as $rec){
-	if($rec->name == $ddnsAddress){
-		$id = $rec->rec_id;
-		$cfIP = $rec->content;
-		break;
-	}
+else {
+    $subdomain   = $hosts[$_GET['auth']];                   // The subdomain that will be updated.
+    $ddnsAddress = $subdomain.".".$myDomain;                // The fully qualified domain name.
 }
 
-// Only update the entry if the IP addresses do not match.
-if ($ip != $cfIP){
-	// Build the request to update the DNS record with our new IP.
-	// https://www.cloudflare.com/docs/client-api.html#s5.2
-	$fields = array(
-		'a' => urlencode('rec_edit'),
-	        'tkn' => urlencode($apiKey),
-		'id' => urlencode($id),
-		'email' => urlencode($emailAddress),
-		'z' => urlencode($myDomain),
-		'type' => urlencode('A'),
-		'name' => urlencode($ddnsAddress),
-		'content' => urlencode($ip),
-		'service_mode' => urlencode('0'),
-		'ttl' => urlencode ('1')
-	);
-	
+$ip           = $_SERVER['REMOTE_ADDR'];                    // The IP of the client calling the script.
+$url          = 'https://www.cloudflare.com/api_json.html'; // The URL for the CloudFlare API.
+
+// Sends request to CloudFlare and returns the response.
+function send_request() {
+	global $url, $fields;
+
 	$fields_string="";
 	foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
 	rtrim($fields_string, '&');
-	
+
 	// Send the request to the CloudFlare API.
 	$ch = curl_init();
 	curl_setopt($ch,CURLOPT_URL, $url);
@@ -94,4 +54,95 @@ if ($ip != $cfIP){
 	curl_setopt($ch,CURLOPT_RETURNTRANSFER, true);
 	$result = curl_exec($ch);
 	curl_close($ch);
+
+	return json_decode($result);
+}
+
+// Determine protocol version and set record type.
+if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+	$type = 'AAAA';
+} else{
+	$type = 'A';
+}
+
+// Build the initial request to fetch the record ID.
+// https://www.cloudflare.com/docs/client-api.html#s3.3
+$fields = array(
+	'a' => urlencode('rec_load_all'),
+	'tkn' => urlencode($apiKey),
+	'email' => urlencode($emailAddress),
+	'z' => urlencode($myDomain)
+);
+
+$data = send_request();
+
+// Continue if the request succeeded.
+if ($data->result == "success") {
+	// Extract the record ID (if it exists) for the subdomain we want to update.
+	$rec_exists = False;						// Assume that the record doesn't exist.
+	foreach($data->response->recs->objs as $rec){
+		if(($rec->name == $ddnsAddress) && ($rec->type == $type)){
+			$rec_exists = True;				// If this runs, it means that the record exists.
+			$id = $rec->rec_id;
+			$cfIP = $rec->content;				// The IP Cloudflare has for the subdomain.
+			break;
+		}
+	}
+
+// Print error message if the request failed.
+} else {
+	die($data->msg."\n");
+}
+
+// Create a new record if it doesn't exist.
+if(!$rec_exists){
+	// Build the request to create a new DNS record.
+	// https://www.cloudflare.com/docs/client-api.html#s5.1
+	$fields = array(
+		'a' => urlencode('rec_new'),
+		'tkn' => urlencode($apiKey),
+		'email' => urlencode($emailAddress),
+		'z' => urlencode($myDomain),
+		'type' => urlencode($type),
+		'name' => urlencode($subdomain),
+		'content' => urlencode($ip),
+		'ttl' => urlencode ('1')
+	);
+
+	$data = send_request();
+
+	// Print success/error message.
+	if ($data->result == "success") {
+		echo $ddnsAddress."/".$type." record successfully created\n";
+	} else {
+		echo $data->msg."\n";
+	}
+
+// Only update the entry if the IP addresses do not match.
+} elseif($ip != $cfIP){
+	// Build the request to update the DNS record with our new IP.
+	// https://www.cloudflare.com/docs/client-api.html#s5.2
+	$fields = array(
+		'a' => urlencode('rec_edit'),
+		'tkn' => urlencode($apiKey),
+		'id' => urlencode($id),
+		'email' => urlencode($emailAddress),
+		'z' => urlencode($myDomain),
+		'type' => urlencode($type),
+		'name' => urlencode($subdomain),
+		'content' => urlencode($ip),
+		'service_mode' => urlencode('0'),
+		'ttl' => urlencode ('1')
+	);
+
+	$data = send_request();
+
+	// Print success/error message.
+	if ($data->result == "success") {
+		echo $ddnsAddress."/".$type." successfully updated to ".$ip."\n";
+	} else {
+		echo $data->msg."\n";
+	}
+} else {
+	echo $ddnsAddress."/".$type." is already up to date\n";
 }

--- a/updateCloudFlare.php
+++ b/updateCloudFlare.php
@@ -30,118 +30,152 @@ $emailAddress = "CloudFlareAccountEmailAddress";            // The email address
 // These values do not need to be changed.
 if (empty($hosts[$_GET['auth']]))
     $ddnsAddress  = $myDomain;                              // If no subdomain is given, update the domain itself.
-else {
-    $subdomain   = $hosts[$_GET['auth']];                   // The subdomain that will be updated.
-    $ddnsAddress = $subdomain.".".$myDomain;                // The fully qualified domain name.
-}
+else
+    $ddnsAddress  = $hosts[$_GET['auth']].".".$myDomain;    // The subdomain that will be updated.
 
 $ip           = $_SERVER['REMOTE_ADDR'];                    // The IP of the client calling the script.
-$url          = 'https://www.cloudflare.com/api_json.html'; // The URL for the CloudFlare API.
+$baseUrl      = 'https://api.cloudflare.com/client/v4/';    // The URL for the CloudFlare API.
+
+// Array with the headers needed for every request
+$headers = array(
+	"X-Auth-Email: ".$emailAddress,
+	"X-Auth-Key: ".$apiKey,
+	"Content-Type: application/json"
+);
 
 // Sends request to CloudFlare and returns the response.
-function send_request() {
-	global $url, $fields;
+function send_request($requestType) {
+	global $url, $fields, $headers;
 
 	$fields_string="";
-	foreach($fields as $key=>$value) { $fields_string .= $key.'='.$value.'&'; }
-	rtrim($fields_string, '&');
+	if ($requestType == "POST" || $requestType == "PUT") {
+		$fields_string = json_encode($fields);
+	}
 
 	// Send the request to the CloudFlare API.
 	$ch = curl_init();
-	curl_setopt($ch,CURLOPT_URL, $url);
-	curl_setopt($ch,CURLOPT_POST, count($fields));
-	curl_setopt($ch,CURLOPT_POSTFIELDS, $fields_string);
-	curl_setopt($ch,CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_URL, $url);
+	curl_setopt($ch, CURLOPT_USERAGENT, "curl");
+	curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $requestType);
+	curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+	if ($requestType == "POST" || $requestType == "PUT") {
+		curl_setopt($ch, CURLOPT_POSTFIELDS, $fields_string);
+	}
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	$result = curl_exec($ch);
 	curl_close($ch);
 
 	return json_decode($result);
 }
 
+// Prints errors and messages and kills the script
+function print_err_msg() {
+	global $data;
+
+	if (!empty($data->errors)) {
+		echo "Errors:\n";
+		print_r($data->errors);
+		echo "\n";
+	}
+	if (!empty($data->messages)) {
+		echo "Messages:\n";
+		print_r($data->messages);
+		echo "\n";
+	}
+	die();
+}
+
 // Determine protocol version and set record type.
-if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
 	$type = 'AAAA';
-} else{
+} else {
 	$type = 'A';
 }
 
-// Build the initial request to fetch the record ID.
-// https://www.cloudflare.com/docs/client-api.html#s3.3
-$fields = array(
-	'a' => urlencode('rec_load_all'),
-	'tkn' => urlencode($apiKey),
-	'email' => urlencode($emailAddress),
-	'z' => urlencode($myDomain)
-);
+//Update $baseUrl
+$baseUrl .= 'zones';
 
-$data = send_request();
+// Build the request to fetch the zone ID.
+// https://api.cloudflare.com/#zone-list-zones
+$url = $baseUrl.'?name='.$myDomain;
+
+$data = send_request("GET");
 
 // Continue if the request succeeded.
-if ($data->result == "success") {
-	// Extract the record ID (if it exists) for the subdomain we want to update.
-	$rec_exists = False;						// Assume that the record doesn't exist.
-	foreach($data->response->recs->objs as $rec){
-		if(($rec->name == $ddnsAddress) && ($rec->type == $type)){
-			$rec_exists = True;				// If this runs, it means that the record exists.
-			$id = $rec->rec_id;
-			$cfIP = $rec->content;				// The IP Cloudflare has for the subdomain.
-			break;
-		}
+if ($data->success) {
+	// Extract the zone ID (if it exists) and update $baseUrl
+	if (!empty($data->result)) {
+		$zoneID = $data->result[0]->id;
+		$baseUrl .= '/'.$zoneID.'/dns_records';
+	} else {
+		die("Zone ".$myDomain." doesn't exist\n");
 	}
 
 // Print error message if the request failed.
 } else {
-	die($data->msg."\n");
+	print_err_msg();
+}
+
+// Build the request to fetch the record ID.
+// https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
+$url = $baseUrl.'?type='.$type;
+$url .= '&name='.$ddnsAddress;
+
+$data = send_request("GET");
+
+// Continue if the request succeeded.
+if ($data->success) {
+	// Extract the record ID (if it exists) for the subdomain we want to update.
+	$rec_exists = false;					// Assume that the record doesn't exist.
+	if (!empty($data->result)) {
+			$rec_exists = true;			// If this runs, it means that the record exists.
+			$id = $data->result[0]->id;
+			$cfIP = $data->result[0]->content;	// The IP Cloudflare has for the subdomain.
+	}
+
+// Print error message if the request failed.
+} else {
+	print_err_msg();
 }
 
 // Create a new record if it doesn't exist.
-if(!$rec_exists){
+if (!$rec_exists) {
 	// Build the request to create a new DNS record.
-	// https://www.cloudflare.com/docs/client-api.html#s5.1
+	// https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
 	$fields = array(
-		'a' => urlencode('rec_new'),
-		'tkn' => urlencode($apiKey),
-		'email' => urlencode($emailAddress),
-		'z' => urlencode($myDomain),
-		'type' => urlencode($type),
-		'name' => urlencode($subdomain),
-		'content' => urlencode($ip),
-		'ttl' => urlencode ('1')
+		'type' => $type,
+		'name' => $ddnsAddress,
+		'content' => $ip,
 	);
+	$url = $baseUrl;
 
-	$data = send_request();
+	$data = send_request("POST");
 
 	// Print success/error message.
-	if ($data->result == "success") {
+	if ($data->success) {
 		echo $ddnsAddress."/".$type." record successfully created\n";
 	} else {
-		echo $data->msg."\n";
+		print_err_msg();
 	}
 
 // Only update the entry if the IP addresses do not match.
-} elseif($ip != $cfIP){
+} elseif ($ip != $cfIP) {
 	// Build the request to update the DNS record with our new IP.
-	// https://www.cloudflare.com/docs/client-api.html#s5.2
+	// https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
 	$fields = array(
-		'a' => urlencode('rec_edit'),
-		'tkn' => urlencode($apiKey),
-		'id' => urlencode($id),
-		'email' => urlencode($emailAddress),
-		'z' => urlencode($myDomain),
-		'type' => urlencode($type),
-		'name' => urlencode($subdomain),
-		'content' => urlencode($ip),
-		'service_mode' => urlencode('0'),
-		'ttl' => urlencode ('1')
+		'name' => $ddnsAddress,
+		'type' => $type,
+		'content' => $ip
 	);
+	$url = $baseUrl.'/'.$id;
 
-	$data = send_request();
+	$data = send_request("PUT");
 
 	// Print success/error message.
-	if ($data->result == "success") {
+	if ($data->success) {
 		echo $ddnsAddress."/".$type." successfully updated to ".$ip."\n";
 	} else {
-		echo $data->msg."\n";
+		print_err_msg();
 	}
 } else {
 	echo $ddnsAddress."/".$type." is already up to date\n";

--- a/updateCloudFlare.sh
+++ b/updateCloudFlare.sh
@@ -1,1 +1,16 @@
-wget -qO- http://www.example.com/updateCloudFlare.php?auth=***Insert Your Key Here*** &> /dev/null
+#!/bin/bash
+
+########## Edit the following lines ##########
+IPv4=true
+IPv6=false
+Logfile="/var/log/ddns.log"
+URL="https://www.example.com/updateCloudFlare.php?auth=***Insert Your Key Here***"
+##############################################
+
+date >> $Logfile
+if $IPv4; then
+  wget -4qO- $URL >> $Logfile
+fi
+if $IPv6; then
+  wget -6qO- $URL >> $Logfile
+fi


### PR DESCRIPTION
The v1 API has been deprecated by Cloudflare since November 9th, 2016.
https://blog.cloudflare.com/sunsetting-api-v1-in-favor-of-cloudflares-current-client-api-api-v4/