### PR TITLE
Support DDNS server being behind Cloudflare

### DIFF
--- a/updateCloudFlare.php
+++ b/updateCloudFlare.php
@@ -34,6 +34,7 @@ else
     $ddnsAddress  = $hosts[$_GET['auth']].".".$myDomain;    // The subdomain that will be updated.
 
 $ip           = $_SERVER['REMOTE_ADDR'];                    // The IP of the client calling the script.
+//$ip         = $_SERVER['HTTP_CF_CONNECTING_IP'];          // Replace the above line with this one if the DDNS server is behind Cloudflare
 $baseUrl      = 'https://api.cloudflare.com/client/v4/';    // The URL for the CloudFlare API.
 
 // Array with the headers needed for every request


### PR DESCRIPTION
Support the scenario where the DDNS server sits behind Cloudflare's reverse proxies.
Add a commented out line to get the client's IP from the HTTP_CF_CONNECTING_IP  header